### PR TITLE
Added the ability to force kill the process on closing the tunnel

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -10,6 +10,10 @@ function getBrowserStackCredentials(pluginOptions) {
   };
 }
 
+function getForceKillOnComplete(pluginOptions) {
+  return process.env.FORCE_KILL_ON_COMPLETE || pluginOptions.forceKillOnComplete
+}
+
 function createBrowserStackTunnel(emitter, pluginOptions) {
   return new Promise((resolve, reject) => {
     const tunnel = pluginOptions.tunnel = pluginOptions.tunnel || {};
@@ -31,6 +35,12 @@ function createBrowserStackTunnel(emitter, pluginOptions) {
 
     function kill() {
       emitter.emit('log:debug', 'browserstack: Stopping tunnel');
+
+      const forceKill = getForceKillOnComplete(pluginOptions);
+      if(forceKill) {
+        process.kill(local.pid);
+      }
+
       return new Promise(resolve => {
         local.stop(error => {
           if (error) {


### PR DESCRIPTION
We currently have an issue on our Jenkins containers where the process just hangs on completion of the tests. I've added the ability to set a _forceKillOnComplete_ flag either on the command line or in the wct.conf allowing people to specify if they want to force the process to be terminated.

I have testes locally on Mac OS and on out containers with success.

It looks like wdio-browserstack have implemented the same from someone as a short term fix. Not sure why this started happening.